### PR TITLE
Delete invalid code to ensure normal startup of the project

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,6 @@
   },
   "packageManager": "pnpm@9.6.0",
   "engines": {
-    "node": "^20.0.0"
+    "node": ">=18.0.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,7 @@
   "umd": "dist/index.umd.js",
   "type": "module",
   "scripts": {
-    "clean": "rm -rf dist",
+    "clean": "rimraf dist",
     "build": "pnpm clean && rollup -c"
   },
   "dependencies": {

--- a/packages/vue3/package.json
+++ b/packages/vue3/package.json
@@ -6,9 +6,17 @@
   "module": "dist/index.js",
   "umd": "dist/index.umd.js",
   "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./dist/style.css": "./dist/style.css"
+  },
+  "style": "dist/style.css",
   "scripts": {
-    "clean": "rm -rf dist",
-    "build": "npm run clean && rollup -c"
+    "clean": "rimraf dist",
+    "build": "pnpm clean && rollup -c"
   },
   "files": [
     "dist",

--- a/packages/vue3/rollup.config.js
+++ b/packages/vue3/rollup.config.js
@@ -1,4 +1,11 @@
 import { baseConfig } from "../../shared/rollup/index.js";
 import pkg from "./package.json" assert { type: "json" };
 
-export default baseConfig({ input: "src/index.js", pkg });
+export default baseConfig({
+  input: "src/index.js",
+  pkg,
+  output: {
+    preserveModules: false,
+    extractCSS: true,
+  },
+});

--- a/packages/vue3/rollup.config.js
+++ b/packages/vue3/rollup.config.js
@@ -4,8 +4,4 @@ import pkg from "./package.json" assert { type: "json" };
 export default baseConfig({
   input: "src/index.js",
   pkg,
-  output: {
-    preserveModules: false,
-    extractCSS: true,
-  },
 });

--- a/packages/vue3/src/index.js
+++ b/packages/vue3/src/index.js
@@ -1,3 +1,5 @@
+import "./styles/index.scss"; // 或其他样式入口文件
+
 export { Editor } from "./editor.js";
 export { default as IsleEditor } from "./isle-editor.js";
 export * from "./kit";

--- a/packages/vue3/src/index.js
+++ b/packages/vue3/src/index.js
@@ -1,5 +1,3 @@
-import "./styles/index.scss"; // 或其他样式入口文件
-
 export { Editor } from "./editor.js";
 export { default as IsleEditor } from "./isle-editor.js";
 export * from "./kit";


### PR DESCRIPTION
感谢指正,项目之前clone下来启动不了,原因其一是样式文件没有正确导出,目前已经在vue3包的package.json 中 改正
`  "type": "module",
  "exports": {
    ".": {
      "import": "./dist/index.js",
      "require": "./dist/index.cjs"
    },
    "./dist/style.css": "./dist/style.css"
  },`,

第二点是在build:packages时,windows用户不能直接使用 rm rf 命令, 也没有对应生成好的dist文件夹可以使用(导出的是dist文件夹),于是在公共包添加rimraf包来解决这个问题。